### PR TITLE
ignore swipe if multiple touches detected

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -19,6 +19,10 @@ export default defineNuxtPlugin((NuxtApp) => {
         }
 
         swipe.setEndEvent(e);
+        if (swipe.hasMultipleTouches()) {
+            swipe = null;
+            return;
+        }
         if (swipe.isSwipeRight()) {
             return NuxtApp.$bus.$emit('swipe', 'right')
         }
@@ -68,6 +72,12 @@ class Swipe {
         return this.getSwipeDirection() == Swipe.SWIPE_DOWN
     }
 
+    hasMultipleTouches() {
+        return (
+            this.startEvent.touches.length > 1 || this.endEvent.touches.length > 1
+        )
+    }
+  
     getSwipeDirection() {
         let start = this.startEvent.changedTouches[0]
         let end = this.endEvent.changedTouches[0]


### PR DESCRIPTION
When processing a swipe, ignore it if there are multiple touches in the start or end event. This helps prevent false swipes from actions such as pinch to zoom. This will fix #1.